### PR TITLE
Implement popsicle error class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode
 coverage
 node_modules
 npm-debug.log

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -5,6 +5,7 @@ import Response from './response'
 import * as plugins from './plugins/index'
 import form from './form'
 import jar from './jar'
+import PopsicleError from './error'
 
 /**
  * Support Popsicle defaults.
@@ -26,6 +27,7 @@ export interface Popsicle {
   plugins: typeof plugins
   Request: typeof Request
   Response: typeof Response
+  Error: typeof PopsicleError
   defaults: (defaults: DefaultsOptions) => Popsicle
   form: typeof form
   jar: typeof jar
@@ -63,7 +65,7 @@ export interface Popsicle {
  * Generate a default popsicle instance.
  */
 export function defaults (defaultsOptions: DefaultsOptions): Popsicle {
-  const popsicle: Popsicle = <any> function popsicle (options: RequestOptions | string) {
+  const popsicle = function popsicle (options: RequestOptions | string) {
     const opts = extendDefaults(defaultsOptions, options)
 
     if (typeof opts.url !== 'string') {
@@ -71,10 +73,11 @@ export function defaults (defaultsOptions: DefaultsOptions): Popsicle {
     }
 
     return new Request(opts)
-  }
+  } as Popsicle
 
   popsicle.Request = Request
   popsicle.Response = Response
+  popsicle.Error = PopsicleError
   popsicle.plugins = plugins
   popsicle.form = form
   popsicle.jar = jar

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -1,0 +1,16 @@
+import makeErrorCause = require('make-error-cause')
+import Request from './request'
+
+export default class PopsicleError extends makeErrorCause.BaseError {
+
+  code: string
+  popsicle: Request
+
+  constructor (message: string, code: string, original: Error, popsicle: Request) {
+    super(message, original)
+
+    this.code = code
+    this.popsicle = popsicle
+  }
+
+}

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -1,5 +1,6 @@
 import Base, { BaseOptions, Headers } from './base'
-import Request, { PopsicleError } from './request'
+import Request from './request'
+import PopsicleError from './error'
 
 export interface ResponseOptions extends BaseOptions {
   body: any

--- a/package.json
+++ b/package.json
@@ -72,13 +72,14 @@
     "tap-spec": "^4.1.1",
     "tape-run": "^2.1.0",
     "typescript": "^1.7.3",
-    "typings": "^0.2.2"
+    "typings": "^0.3.1"
   },
   "dependencies": {
     "arrify": "^1.0.0",
     "concat-stream": "^1.4.7",
     "form-data": "^0.2.0",
     "infinity-agent": "^2.0.3",
+    "make-error-cause": "^1.0.1",
     "methods": "^1.1.1",
     "native-or-bluebird": "^1.2.0",
     "tough-cookie": "^2.0.0",

--- a/test/index.ts
+++ b/test/index.ts
@@ -354,7 +354,7 @@ test('timeout', function (t) {
     })
       .catch(function (err) {
         t.equal(err.message, 'Timeout of 500ms exceeded')
-        t.equal(err.type, 'ETIMEOUT')
+        t.equal(err.code, 'ETIMEOUT')
         t.ok(err.popsicle instanceof popsicle.Request)
       })
   })
@@ -371,7 +371,7 @@ test('abort', function (t) {
     return req
       .catch(function (err) {
         t.equal(err.message, 'Request aborted')
-        t.equal(err.type, 'EABORT')
+        t.equal(err.code, 'EABORT')
         t.ok(err.popsicle instanceof popsicle.Request)
       })
   })
@@ -388,7 +388,7 @@ test('abort', function (t) {
     return req
       .catch(function (err) {
         t.equal(err.message, 'Request aborted')
-        t.equal(err.type, 'EABORT')
+        t.equal(err.code, 'EABORT')
         t.ok(err.popsicle instanceof popsicle.Request)
       })
   })
@@ -404,7 +404,7 @@ test('abort', function (t) {
     return req
       .catch(function (err) {
         t.equal(err.message, 'Request aborted')
-        t.equal(err.type, 'EABORT')
+        t.equal(err.code, 'EABORT')
         t.ok(err.popsicle instanceof popsicle.Request)
       })
   })
@@ -630,7 +630,7 @@ test('response body', function (t) {
       })
         .catch(function (err) {
           t.equal(err.message, 'Unsupported response type: foobar')
-          t.equal(err.type, 'ERESPONSETYPE')
+          t.equal(err.code, 'ERESPONSETYPE')
         })
     })
   }
@@ -643,7 +643,7 @@ test('request errors', function (t) {
     return popsicle('http://fdahkfjhuehfakjbvdahjfds.fdsa')
       .catch(function (err) {
         t.ok(/Unable to connect/i.exec(err.message))
-        t.equal(err.type, 'EUNAVAILABLE')
+        t.equal(err.code, 'EUNAVAILABLE')
         t.ok(err.popsicle instanceof popsicle.Request)
       })
   })
@@ -661,7 +661,7 @@ test('request errors', function (t) {
     })
       .catch(function (err) {
         t.ok(/Unable to parse response body/i.test(err.message))
-        t.equal(err.type, 'EPARSE')
+        t.equal(err.code, 'EPARSE')
         t.ok(err.popsicle instanceof popsicle.Request)
       })
   })
@@ -681,7 +681,7 @@ test('request errors', function (t) {
     })
       .catch(function (err) {
         t.ok(/Unable to stringify request body/i.test(err.message))
-        t.equal(err.type, 'ESTRINGIFY')
+        t.equal(err.code, 'ESTRINGIFY')
         t.ok(err.popsicle instanceof popsicle.Request)
       })
   })
@@ -952,7 +952,7 @@ if (!popsicle.browser) {
       return popsicle(REMOTE_URL + '/redirect/6')
         .catch(function (err) {
           t.equal(err.message, 'Exceeded maximum of 5 redirects')
-          t.equal(err.type, 'EMAXREDIRECTS')
+          t.equal(err.code, 'EMAXREDIRECTS')
         })
     })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "outDir": "dist",
     "module": "commonjs",
+    "moduleResolution": "classic",
     "declaration": true,
     "noImplicitAny": true,
     "removeComments": true,
@@ -14,6 +15,7 @@
     "lib/browser/form-data.ts",
     "lib/browser/tough-cookie.ts",
     "lib/plugins/browser.ts",
+    "custom_typings/env.d.ts",
     "typings/main.d.ts",
     "test/index.ts"
   ]

--- a/typings.json
+++ b/typings.json
@@ -3,7 +3,6 @@
     "blue-tape": "github:typings/typed-blue-tape#a4e41a85d6f760e7c60088127968eae7d3a556fa"
   },
   "ambientDependencies": {
-    "missing-global-typings": "file:custom_typings/env.d.ts",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#8cf8164641be73e8f1e652c2a5b967c7210b6729"
   },
   "dependencies": {
@@ -11,6 +10,7 @@
     "concat-stream": "github:typings/typed-concat-stream#099a88b57dcc9968246e8b1b3651e914a1a2c324",
     "form-data": "github:typings/typed-form-data#edc32200ec6065d98bfaa7ff9cfd104e17c5d3e4",
     "infinity-agent": "github:typings/typed-infinity-agent#545612609b0d4b36ba98b3f2c0f83484af1978ae",
+    "make-error-cause": "npm:make-error-cause",
     "methods": "github:typings/typed-methods#b902fa13683e95d54b2bb69188f68ea3525ec430",
     "native-or-bluebird": "github:typings/typed-native-or-bluebird#e9b7a479d68931ef88895d578860456bfbe91faa",
     "tough-cookie": "github:typings/typed-tough-cookie#3e37dc2e6d448130d2fa4be1026e195ffda2b398",


### PR DESCRIPTION
Uses `make-error-cause` to chain error instances in a semi-standard way. Switched to using `code` over `type`.

Closes https://github.com/blakeembrey/popsicle/issues/28