### PR TITLE
Export CookieJar for tough-cookie browser typings override. Avoids tsc error

### DIFF
--- a/lib/browser/tough-cookie.ts
+++ b/lib/browser/tough-cookie.ts
@@ -1,3 +1,11 @@
-export = function ToughCookie () {
+function ToughCookie () {
   throw new TypeError('Cookie jars are only available on node')
 }
+
+export class CookieJar {
+  constructor() {
+    ToughCookie();
+  }
+}
+
+export default ToughCookie;


### PR DESCRIPTION
The tough-cookie override for browser typings does not export CookieJar, this leads to a typescript compile error when using browser typings as popsicle/lib/jar.ts imports CookieJar.

See demonstration: https://github.com/garethhunt/popsicle-browser-repro