### PR TITLE
Add "types" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "8.2.0",
   "description": "Simple HTTP requests for node and the browser",
   "main": "dist/common.js",
+  "types": "dist/common.d.ts",
   "files": [
     "dist/",
     "typings.json",


### PR DESCRIPTION
The `types` field in `package.json` allows TypeScript 2 to automatically use the type declaration without needing to install it specifically through the `typings` tool.

More info: https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/declaration%20files/Publishing.md